### PR TITLE
Adds "Unsafe" clients for non-formatted string requests

### DIFF
--- a/PrincipleStudios.Salesforce/ISalesforceHttpClient.cs
+++ b/PrincipleStudios.Salesforce/ISalesforceHttpClient.cs
@@ -10,6 +10,10 @@ public interface ISalesforceClient : ISalesforceHttpClient, ISalesforceQueryClie
 {
 }
 
+public interface IUnsafeSalesforceClient : ISalesforceClient, IUnsafeSalesforceQueryClient, IUnsafeSalesforceSearchClient
+{
+}
+
 /// <summary>
 /// A Salesforce HTTP client.
 /// </summary>
@@ -30,11 +34,33 @@ public interface ISalesforceQueryClient
     /// Issues a SOQL query.
     /// </summary>
     /// <typeparam name="T">The type of each record</typeparam>
-    /// <param name="query">The SOQL query as a FormattableString.</param>
+    /// <param name="query">The SOQL query as a FormattableString. Parameters will be automatically escaped and enclosed with appropriate SOQL symbols, such as single quotes for strings.</param>
     /// <param name="options">Options for the SOQL query. Optional.</param>
     /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
     /// <returns>The parsed response from Salesforce. <seealso cref="QueryResponse<>"/></returns>
     Task<QueryResponse<T>> QueryAsync<T>(FormattableString query, SalesforceRequestOptions options = default, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves the next page of data from a SOQL query.
+    /// </summary>
+    /// <typeparam name="T">The type of each record</typeparam>
+    /// <param name="previous">The response from the previous request.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    /// <returns>The parsed response from Salesforce. <seealso cref="QueryResponse<>"/></returns>
+    Task<QueryResponse<T>> NextAsync<T>(QueryResponse<T> previous, SalesforceRequestOptions options = default, CancellationToken cancellationToken = default);
+}
+
+public interface IUnsafeSalesforceQueryClient
+{
+    /// <summary>
+    /// Issues a SOQL query.
+    /// </summary>
+    /// <typeparam name="T">The type of each record</typeparam>
+    /// <param name="query">The SOQL query.</param>
+    /// <param name="options">Options for the SOQL query. Optional.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    /// <returns>The parsed response from Salesforce. <seealso cref="QueryResponse<>"/></returns>
+    Task<QueryResponse<T>> UnsafeQueryAsync<T>(string query, SalesforceRequestOptions options = default, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Retrieves the next page of data from a SOQL query.
@@ -52,11 +78,24 @@ public interface ISalesforceSearchClient
     /// Issues a SOSL search.
     /// </summary>
     /// <typeparam name="T">The type of each record</typeparam>
-    /// <param name="query">The SOSL query.</param>
+    /// <param name="query">The SOSL query as a FormattableString. Parameters will be automatically escaped and enclosed with appropriate SOSL symbols, such as single quotes for strings.</param>
     /// <param name="options">Options for the SOQL query. Optional.</param>
     /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
     /// <returns>The parsed response from Salesforce. <seealso cref="SearchResponse<>"/></returns>
     Task<SearchResponse<T>> SearchAsync<T>(FormattableString query, SalesforceRequestOptions options = default, CancellationToken cancellationToken = default);
+}
+
+public interface IUnsafeSalesforceSearchClient
+{
+    /// <summary>
+    /// Issues a SOSL search.
+    /// </summary>
+    /// <typeparam name="T">The type of each record</typeparam>
+    /// <param name="query">The SOSL query.</param>
+    /// <param name="options">Options for the SOQL query. Optional.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+    /// <returns>The parsed response from Salesforce. <seealso cref="SearchResponse<>"/></returns>
+    Task<SearchResponse<T>> UnsafeSearchAsync<T>(string query, SalesforceRequestOptions options = default, CancellationToken cancellationToken = default);
 }
 
 /// <summary>

--- a/PrincipleStudios.Salesforce/SalesforceClient.cs
+++ b/PrincipleStudios.Salesforce/SalesforceClient.cs
@@ -3,7 +3,7 @@ using System.Text.Json;
 
 namespace PrincipleStudios.Salesforce;
 
-public class SalesforceClient : ISalesforceClient
+public class SalesforceClient : ISalesforceClient, IUnsafeSalesforceClient
 {
     private readonly string apiVersion;
     private readonly HttpClient httpClient;
@@ -25,12 +25,11 @@ public class SalesforceClient : ISalesforceClient
 
         var q = query.ToSoqlQuery(options.SkipTrim);
         logger.LogSoqlQuery(q.FinalQuery, q.Format);
-        var fullUrl = new Uri(instanceUrl, $"services/data/{options.ApiVersion ?? apiVersion}/query/?q={Uri.EscapeDataString(q.FinalQuery)}");
-
-        using var response = await httpClient.GetAsync(fullUrl, cancellationToken).ConfigureAwait(false);
-        var result = await DeserializeFromResponseStreamAsync<QueryResponse<T>>(response, options.SerializerOptions, cancellationToken).ConfigureAwait(false);
-        return result;
+        return await QueryImplementation<T>(q.FinalQuery, options, cancellationToken).ConfigureAwait(false);
     }
+
+    public Task<QueryResponse<T>> UnsafeQueryAsync<T>(string query, SalesforceRequestOptions options = default, CancellationToken cancellationToken = default) =>
+        QueryImplementation<T>(query, options, cancellationToken);
 
     public async Task<QueryResponse<T>> NextAsync<T>(QueryResponse<T> previous, SalesforceRequestOptions options = default, CancellationToken cancellationToken = default)
     {
@@ -51,12 +50,11 @@ public class SalesforceClient : ISalesforceClient
 
         var q = query.ToSoslQuery(options.SkipTrim);
         logger.LogSoslSearch(q.FinalQuery, q.Format);
-        var fullUrl = new Uri(instanceUrl, $"services/data/{options.ApiVersion ?? apiVersion}/search/?q={Uri.EscapeDataString(q.FinalQuery)}");
-
-        using var response = await httpClient.GetAsync(fullUrl, cancellationToken).ConfigureAwait(false);
-        var result = await DeserializeFromResponseStreamAsync<SearchResponse<T>>(response, options.SerializerOptions, cancellationToken).ConfigureAwait(false);
-        return result;
+        return await SearchImplementation<T>(q.FinalQuery, options, cancellationToken).ConfigureAwait(false);
     }
+
+    public Task<SearchResponse<T>> UnsafeSearchAsync<T>(string query, SalesforceRequestOptions options = default, CancellationToken cancellationToken = default) =>
+        SearchImplementation<T>(query, options, cancellationToken);
 
     public Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken = default)
     {
@@ -74,5 +72,23 @@ public class SalesforceClient : ISalesforceClient
             await responseMessage.Content.ReadAsStreamAsync().ConfigureAwait(false);
 #endif
         return await JsonSerializer.DeserializeAsync<T>(responseStream, serializerOptions, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<QueryResponse<T>> QueryImplementation<T>(string query, SalesforceRequestOptions options = default, CancellationToken cancellationToken = default)
+    {
+        var fullUrl = new Uri(instanceUrl, $"services/data/{options.ApiVersion ?? apiVersion}/query/?q={Uri.EscapeDataString(query)}");
+
+        using var response = await httpClient.GetAsync(fullUrl, cancellationToken).ConfigureAwait(false);
+        var result = await DeserializeFromResponseStreamAsync<QueryResponse<T>>(response, options.SerializerOptions, cancellationToken).ConfigureAwait(false);
+        return result;
+    }
+
+    private async Task<SearchResponse<T>> SearchImplementation<T>(string query, SalesforceRequestOptions options = default, CancellationToken cancellationToken = default)
+    {
+        var fullUrl = new Uri(instanceUrl, $"services/data/{options.ApiVersion ?? apiVersion}/search/?q={Uri.EscapeDataString(query)}");
+
+        using var response = await httpClient.GetAsync(fullUrl, cancellationToken).ConfigureAwait(false);
+        var result = await DeserializeFromResponseStreamAsync<SearchResponse<T>>(response, options.SerializerOptions, cancellationToken).ConfigureAwait(false);
+        return result;
     }
 }


### PR DESCRIPTION
Adds methods to use `string` queries for building queries without placeholders. These methods are marked `Unsafe` to indicate to the developer that parameterized queries are not used.